### PR TITLE
Fix config-device-connection VSCode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -61,13 +61,13 @@
             "taskName": "config-device-connection",
             "command": "node",
             "windows": {
-                "args": ["'${env:USERPROFILE}\\azure-board-cli\\out\\cli.js'", "config_device_connection", ".bin"]
+                "args": ["'${env:USERPROFILE}\\azure-board-cli\\out\\cli.js'", "config_device_connection_string", ".bin"]
             },
             "linux": {
-                "args": ["\"$HOME/azure-board-cli/out/cli.js\"", "config_device_connection", ".bin"]
+                "args": ["\"$HOME/azure-board-cli/out/cli.js\"", "config_device_connection_string", ".bin"]
             },
             "osx": {
-                "args": ["\"/Users/$USER/azure-board-cli/out/cli.js\"", "config_device_connection", ".bin"]
+                "args": ["\"/Users/$USER/azure-board-cli/out/cli.js\"", "config_device_connection_string", ".bin"]
             },
             "isShellCommand": true,
             "isBuildCommand": false


### PR DESCRIPTION
Latest cli/firmware expects `config_device_connection_string` instead of `config_device_connection`.

```powershell
PS C:\Users\user> cat azure-board-cli\out\cli.js | select-string config_device_connection

} else if (action === 'config_device_connection_string') {
    telemetry.trace("running task: config_device_connection_string");
    registerTasks({ 'config': ['config_device_connection_string'] });
```