### PR TITLE
Fix .css for better RGB LED fidelity

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -696,7 +696,7 @@ body {
     left: 26%;
 }
 
-.devkit .connecion_status {
+.devkit .connection_status {
     position: absolute;
     bottom: 36%;
     left: 26%;
@@ -790,11 +790,13 @@ body {
 }
 
 .devkit .rgb_led {
-    width: 12%;
-    height: 8%;
+    left: 7.7%;
+    width: 5%;
+    height: 3.3%;
     position: absolute;
-    top: 70%;
-    left: 4%;
+    top: 71%;
+    border: green 1px solid;
+    border-radius: 50%;
     cursor: pointer;
     z-index: 100;
 }
@@ -802,15 +804,42 @@ body {
 .devkit .rgb_led:before {
     content: "";
     position: absolute;
-    width: 20%;
-    height: 20%;
-    top: 40%;
-    left: 40%;
-    border: green 1px solid;
-    border-radius: 50%;
+    width: 30%;
+    height: 100%;
+    left: -30%;
+    top: 0;
+    background-image: linear-gradient(
+        transparent,
+        transparent 40%,
+        green 40%,
+        green 60%,
+        transparent 60%,
+        transparent
+    );
+    background-size: 100% 50%;
+    background-repeat: repeat-y;
 }
 
-.devkit .rgb_led.on:before {
+.devkit .rgb_led:after {
+    content: "";
+    position: absolute;
+    width: 30%;
+    height: 100%;
+    right: -30%;
+    top: 0;
+    background-image: linear-gradient(
+        transparent,
+        transparent 40%,
+        green 40%,
+        green 60%,
+        transparent 60%,
+        transparent
+    );
+    background-size: 100% 50%;
+    background-repeat: repeat-y;
+}
+
+.devkit .rgb_led.on {
     background: green;
 }
 


### PR DESCRIPTION
You need to take in both PRs for the LED to update dynamically in UI. I kind of messed up the PR, my bad.
My fontend-fu is weak with both CSS and Vue so i'm sure it can be improved, the v-bindings look a bit awful now but it works :)

~~I should probably build a computed style object and bind that instead of doing it inline..~~
Nevermind, fixed it, added computed style and referenced in `v-bind:style` for much cleaner markup. Also learned some Vue.js in the process. So far so good.